### PR TITLE
fix: Add github token to release-please workflow #27

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: go
-
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I added the github token to our release please, but every one needs to add the workflow permissions to their PAT or else it wont allow them to push anything at all. 